### PR TITLE
[RFC] Multiple changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The driver requires a node in the device tree. This node describes the DMA chann
 * `compatible` - This must be the string "xlnx,axidma-chrdev". This is used to match the driver with the device tree node.
 * `dmas` - A list of phandles (references to other device tree nodes) of Xilinx AXI DMA or VDMA device tree nodes, followed by either 0 or 1. This refers to the child node inside of the Xilinx AXI DMA/VDMA device tree node, 0 of course being the first child node.
 * `dma-names` - A list of names for the DMA channels. The names can be completely arbitrary, but they must be unique. This is required by the DMA interface function `dma_request_slave_channel()`, but is otherwise unused by the driver. In the future, the driver will use the names in printed messages.
+* `index` - A non-negative integer which represents the index of this DMA device, optional if only one DMA device is present. If unset, defaults to 0.  The indexes are not required to be consecutive, but they must be unique. The corresponding character device will appear as `/dev/axidma` when index is 0 or `/dev/axidma<index>` otherwise.
 
 For the Xilinx AXI DMA/VDMA device tree nodes, the only requirement is that the `device-id` property is unique, but they can be completely arbitrary. This is how the channels are referred to in both the driver and from userspace. For more information on creating AXI DMA/VDMA device tree nodes, consult the kernel [documentation](https://github.com/Xilinx/linux-xlnx/blob/master/Documentation/devicetree/bindings/dma/xilinx/xilinx_dma.txt) for them.
 

--- a/driver/axi_dma.c
+++ b/driver/axi_dma.c
@@ -99,6 +99,8 @@ static const struct of_device_id axidma_compatible_of_ids[] = {
     {}
 };
 
+MODULE_DEVICE_TABLE(of, axidma_compatible_of_ids);
+
 static struct platform_driver axidma_driver = {
     .driver = {
         .name = MODULE_NAME,

--- a/driver/axi_dma.c
+++ b/driver/axi_dma.c
@@ -51,17 +51,34 @@ static int axidma_probe(struct platform_device *pdev)
     // Initialize the DMA interface
     rc = axidma_dma_init(pdev, axidma_dev);
     if (rc < 0) {
+        rc = -ENOSYS;
         goto free_axidma_dev;
     }
 
     // Assign the character device name, minor number, and number of devices
-    axidma_dev->chrdev_name = chrdev_name;
     axidma_dev->minor_num = minor_num;
     axidma_dev->num_devices = NUM_DEVICES;
+
+    if (axidma_dev->chrdev_index > 0) {
+        rc = strlen(chrdev_name) + 10;
+        axidma_dev->chrdev_name = kmalloc(rc * sizeof(char), GFP_KERNEL);
+
+        if (axidma_dev->chrdev_name == NULL) {
+            axidma_err("Unable to allocate the AXI DMA chardev name string.\n");
+            rc = -ENOMEM;
+            goto free_axidma_dev;
+        }
+
+        snprintf(axidma_dev->chrdev_name, rc, "%s%d", chrdev_name,
+                 axidma_dev->chrdev_index);
+    }
+    else
+         axidma_dev->chrdev_name = chrdev_name;
 
     // Initialize the character device for the module.
     rc = axidma_chrdev_init(axidma_dev);
     if (rc < 0) {
+        rc = -ENOSYS;
         goto destroy_dma_dev;
     }
 
@@ -71,9 +88,11 @@ static int axidma_probe(struct platform_device *pdev)
 
 destroy_dma_dev:
     axidma_dma_exit(axidma_dev);
+    if (axidma_dev->chrdev_index > 0)
+        kfree(axidma_dev->chrdev_name);
 free_axidma_dev:
     kfree(axidma_dev);
-    return -ENOSYS;
+    return rc;
 }
 
 static int axidma_remove(struct platform_device *pdev)
@@ -90,7 +109,11 @@ static int axidma_remove(struct platform_device *pdev)
     axidma_dma_exit(axidma_dev);
 
     // Free the device structure
+    if (axidma_dev->chrdev_index > 0)
+        kfree(axidma_dev->chrdev_name);
+
     kfree(axidma_dev);
+
     return 0;
 }
 

--- a/driver/axidma.h
+++ b/driver/axidma.h
@@ -51,6 +51,7 @@ struct axidma_device {
     unsigned int minor_num;         // The minor number of the device
     dev_t dev_num;                  // The device number of the device
     char *chrdev_name;              // The name of the character device
+    int chrdev_index;               // The optional character device index
     struct device *device;          // Device structure for the char device
     struct class *dev_class;        // The device class for the chardevice
     struct cdev chrdev;             // The character device structure
@@ -61,6 +62,7 @@ struct axidma_device {
     int num_vdma_rx_chans;          // The number of receive  VDMA channels
     int num_chans;                  // The total number of DMA channels
     int notify_signal;              // Signal used to notify transfer completion
+    void *user_data;                // User data to be passed in the callback
     struct platform_device *pdev;   // The platofrm device from the device tree
     struct axidma_cb_data *cb_data; // The callback data for each channel
     struct axidma_chan *channels;   // All available channels
@@ -98,7 +100,7 @@ void axidma_get_num_channels(struct axidma_device *dev,
                              struct axidma_num_channels *num_chans);
 void axidma_get_channel_info(struct axidma_device *dev,
                              struct axidma_channel_info *chan_info);
-int axidma_set_signal(struct axidma_device *dev, int signal);
+int axidma_set_signal(struct axidma_device *dev, int signal, void *user_data);
 int axidma_read_transfer(struct axidma_device *dev,
                           struct axidma_transaction *trans);
 int axidma_write_transfer(struct axidma_device *dev,

--- a/driver/axidma.h
+++ b/driver/axidma.h
@@ -107,6 +107,7 @@ int axidma_rw_transfer(struct axidma_device *dev,
                        struct axidma_inout_transaction *trans);
 int axidma_video_write_transfer(struct axidma_device *dev,
                                 struct axidma_video_transaction *trans);
+int axidma_get_residue(struct axidma_device *dev, struct axidma_residue *res);
 int axidma_stop_channel(struct axidma_device *dev, struct axidma_chan *chan);
 dma_addr_t axidma_uservirt_to_dma(struct axidma_device *dev, void *user_addr,
                                   size_t size);

--- a/driver/axidma_chrdev.c
+++ b/driver/axidma_chrdev.c
@@ -344,6 +344,7 @@ static long axidma_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
     struct axidma_transaction trans;
     struct axidma_inout_transaction inout_trans;
     struct axidma_video_transaction video_trans;
+    struct axidma_residue residue;
     struct axidma_chan chan_info;
 
     // Coerce the arguement as a userspace pointer
@@ -463,6 +464,20 @@ static long axidma_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
             }
 
             rc = axidma_video_write_transfer(dev, &video_trans);
+            break;
+
+        case AXIDMA_DMA_RESIDUE:
+            if (copy_from_user(&residue, arg_ptr, sizeof(residue)) != 0) {
+                axidma_err("Unable to copy residue info from userspace for "
+                           "AXIDMA_DMA_RESIDUE.\n");
+                return -EFAULT;
+            }
+            rc = axidma_get_residue(dev, &residue);
+            if (copy_to_user(arg_ptr, &residue, sizeof(residue)) != 0) {
+                axidma_err("Unable to copy residue info to userspace for "
+                           "AXIDMA_DMA_RESIDUE.\n");
+                return -EFAULT;
+            }
             break;
 
         case AXIDMA_STOP_DMA_CHANNEL:

--- a/driver/axidma_chrdev.c
+++ b/driver/axidma_chrdev.c
@@ -34,9 +34,6 @@
  * Internal Definitions
  *----------------------------------------------------------------------------*/
 
-// TODO: Maybe this can be improved?
-static struct axidma_device *axidma_dev;
-
 // A structure that represents a DMA buffer allocation
 struct axidma_dma_allocation {
     size_t size;                // Size of the buffer
@@ -44,6 +41,7 @@ struct axidma_dma_allocation {
     void *kern_addr;            // Kernel virtual address of the buffer
     dma_addr_t dma_addr;        // DMA bus address of the buffer
     struct list_head list;      // List node pointers for allocation list
+    struct device *device;      // Device structure for the char device
 };
 
 /* A structure that represents a DMA buffer allocation imported from another
@@ -202,13 +200,11 @@ static int axidma_put_external(struct axidma_device *dev, void *user_addr)
 
 static void axidma_vma_close(struct vm_area_struct *vma)
 {
-    struct axidma_device *dev;
     struct axidma_dma_allocation *dma_alloc;
 
     // Get the AXI DMA allocation data and free the DMA buffer
-    dev = axidma_dev;
     dma_alloc = vma->vm_private_data;
-    dma_free_coherent(dev->device, dma_alloc->size, dma_alloc->kern_addr,
+    dma_free_coherent(dma_alloc->device, dma_alloc->size, dma_alloc->kern_addr,
                       dma_alloc->dma_addr);
 
     // Remove the allocation from the list, and free the structure
@@ -239,7 +235,8 @@ static int axidma_open(struct inode *inode, struct file *file)
     }
 
     // Place the axidma structure in the private data of the file
-    file->private_data = (void *)axidma_dev;
+    file->private_data = container_of(inode->i_cdev, struct axidma_device,
+                                      chrdev);
     return 0;
 }
 
@@ -269,6 +266,7 @@ static int axidma_mmap(struct file *file, struct vm_area_struct *vma)
     // Set the user virtual address and the size
     dma_alloc->size = vma->vm_end - vma->vm_start;
     dma_alloc->user_addr = (void *)vma->vm_start;
+    dma_alloc->device = dev->device;
 
     // Configure the DMA device
     of_dma_configure(dev->device, NULL);
@@ -340,6 +338,7 @@ static long axidma_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
     struct axidma_device *dev;
     struct axidma_num_channels num_chans;
     struct axidma_channel_info usr_chans, kern_chans;
+    struct axidma_signal_info sig_info;
     struct axidma_register_buffer ext_buf;
     struct axidma_transaction trans;
     struct axidma_inout_transaction inout_trans;
@@ -406,7 +405,12 @@ static long axidma_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
             break;
 
         case AXIDMA_SET_DMA_SIGNAL:
-            rc = axidma_set_signal(dev, arg);
+            if (copy_from_user(&sig_info, arg_ptr, sizeof(sig_info)) != 0) {
+                axidma_err("Unable to copy signal info from userspace for "
+                           "AXIDMA_SET_DMA_SIGNAL.\n");
+                return -EFAULT;
+            }
+            rc = axidma_set_signal(dev, sig_info.signal, sig_info.user_data);
             break;
 
         case AXIDMA_REGISTER_BUFFER:
@@ -516,9 +520,6 @@ static const struct file_operations axidma_fops = {
 int axidma_chrdev_init(struct axidma_device *dev)
 {
     int rc;
-
-    // Store a global pointer to the axidma device
-    axidma_dev = dev;
 
     // Allocate a major and minor number region for the character device
     rc = alloc_chrdev_region(&dev->dev_num, dev->minor_num, dev->num_devices,

--- a/driver/axidma_dma.c
+++ b/driver/axidma_dma.c
@@ -606,6 +606,23 @@ ret:
     return 0;
 }
 
+int axidma_get_residue(struct axidma_device *dev, struct axidma_residue *res)
+{
+    struct axidma_chan *chan;
+    struct dma_tx_state state;
+
+    chan = axidma_get_chan(dev, res->channel_id);
+
+    if (chan != NULL) {
+        dmaengine_tx_status(chan->chan, chan->chan->cookie, &state);
+        res->residue = state.residue;
+
+        return 0;
+    }
+    else
+        return -ENODEV;
+}
+
 int axidma_stop_channel(struct axidma_device *dev,
                         struct axidma_chan *chan_info)
 {

--- a/driver/axidma_dma.c
+++ b/driver/axidma_dma.c
@@ -51,6 +51,7 @@ struct axidma_transfer {
     enum axidma_type type;          // The type of the transfer (VDMA/DMA)
     int channel_id;                 // The ID of the channel
     int notify_signal;              // The signal to use for async transfers
+    void *user_data;                // User data to be passed in the callback
     struct task_struct *process;    // The process requesting the transfer
     struct axidma_cb_data *cb_data; // The callback data struct
 
@@ -68,6 +69,7 @@ struct axidma_transfer {
 struct axidma_cb_data {
     int channel_id;                 // The id of the channel used
     int notify_signal;              // For async, signal to send
+    void *user_data;                // User data to be passed in the callback
     struct task_struct *process;    // The process to send the signal to
     struct completion *comp;        // For sync, the notification to kernel
 };
@@ -151,7 +153,8 @@ static void axidma_dma_callback(void *data)
         memset(&sig_info, 0, sizeof(sig_info));
         sig_info.si_signo = cb_data->notify_signal;
         sig_info.si_code = SI_QUEUE;
-        sig_info.si_int = cb_data->channel_id;
+        sig_info.si_errno = cb_data->channel_id;    //This shouldn't be here
+        sig_info.si_ptr = cb_data->user_data;
         send_sig_info(cb_data->notify_signal, &sig_info, cb_data->process);
     }
 }
@@ -238,9 +241,11 @@ static int axidma_prep_transfer(struct axidma_chan *axidma_chan,
     /* If we're going to wait for this channel, initialize the completion for
      * the channel, and setup the callback to complete it. */
     cb_data->channel_id = dma_tfr->channel_id;
+    cb_data->user_data = dma_tfr->user_data;
     if (dma_tfr->wait) {
         cb_data->comp = dma_comp;
         cb_data->notify_signal = -1;
+        cb_data->user_data = dma_tfr->user_data;
         cb_data->process = NULL;
         init_completion(cb_data->comp);
         dma_txnd->callback_param = cb_data;
@@ -248,6 +253,7 @@ static int axidma_prep_transfer(struct axidma_chan *axidma_chan,
     } else {
         cb_data->comp = NULL;
         cb_data->notify_signal = dma_tfr->notify_signal;
+        cb_data->user_data = dma_tfr->user_data;
         cb_data->process = dma_tfr->process;
         dma_txnd->callback_param = cb_data;
         dma_txnd->callback = axidma_dma_callback;
@@ -335,7 +341,7 @@ void axidma_get_channel_info(struct axidma_device *dev,
     return;
 }
 
-int axidma_set_signal(struct axidma_device *dev, int signal)
+int axidma_set_signal(struct axidma_device *dev, int signal, void *user_data)
 {
     // Verify the signal is a real-time one
     if (!VALID_NOTIFY_SIGNAL(signal)) {
@@ -346,6 +352,7 @@ int axidma_set_signal(struct axidma_device *dev, int signal)
     }
 
     dev->notify_signal = signal;
+    dev->user_data = user_data;
     return 0;
 }
 
@@ -381,6 +388,7 @@ int axidma_read_transfer(struct axidma_device *dev,
     rx_tfr.wait = trans->wait;
     rx_tfr.channel_id = trans->channel_id;
     rx_tfr.notify_signal = dev->notify_signal;
+    rx_tfr.user_data = dev->user_data;
     rx_tfr.process = get_current();
     rx_tfr.cb_data = &dev->cb_data[trans->channel_id];
 
@@ -431,6 +439,7 @@ int axidma_write_transfer(struct axidma_device *dev,
     tx_tfr.wait = trans->wait;
     tx_tfr.channel_id = trans->channel_id;
     tx_tfr.notify_signal = dev->notify_signal;
+    tx_tfr.user_data = dev->user_data;
     tx_tfr.process = get_current();
     tx_tfr.cb_data = &dev->cb_data[trans->channel_id];
 
@@ -496,6 +505,7 @@ int axidma_rw_transfer(struct axidma_device *dev,
     tx_tfr.wait = false,
     tx_tfr.channel_id = trans->tx_channel_id,
     tx_tfr.notify_signal = dev->notify_signal,
+    tx_tfr.user_data = dev->user_data;
     tx_tfr.process = get_current(),
     tx_tfr.cb_data = &dev->cb_data[trans->tx_channel_id];
     // FIXME: FIXME: FIXME: Temporary
@@ -510,6 +520,7 @@ int axidma_rw_transfer(struct axidma_device *dev,
     rx_tfr.wait = trans->wait,
     rx_tfr.channel_id = trans->rx_channel_id,
     rx_tfr.notify_signal = dev->notify_signal,
+    rx_tfr.user_data = dev->user_data;
     rx_tfr.process = get_current(),
     rx_tfr.cb_data = &dev->cb_data[trans->rx_channel_id];
     rx_tfr.vdma_tfr.height = 1080;
@@ -555,6 +566,7 @@ int axidma_video_write_transfer(struct axidma_device *dev,
         .wait = false,
         .channel_id = trans->channel_id,
         .notify_signal = dev->notify_signal,
+        .user_data = dev->user_data,
         .process = get_current(),
         .vdma_tfr.width = trans->width,
         .vdma_tfr.height = trans->height,

--- a/driver/axidma_of.c
+++ b/driver/axidma_of.c
@@ -212,6 +212,14 @@ int axidma_of_parse_dma_nodes(struct platform_device *pdev,
     dev->num_vdma_tx_chans = 0;
     dev->num_vdma_rx_chans = 0;
 
+    rc = of_property_read_u32(driver_node, "index", &dev->chrdev_index);
+
+    if (rc < 0) {
+        if (rc != -EINVAL)
+            axidma_node_err(driver_node, "Invalid index property, ignoring.\n");
+        dev->chrdev_index = -1;
+    }
+
     /* For each DMA channel specified in the deivce tree, parse out the
      * information about the channel, namely its direction and type. */
     for (i = 0; i < dev->num_chans; i++)

--- a/include/axidma_ioctl.h
+++ b/include/axidma_ioctl.h
@@ -76,6 +76,11 @@ struct axidma_channel_info {
     struct axidma_chan *channels;   // Metadata about all available channels
 };
 
+struct axidma_signal_info {
+    int signal;
+    void *user_data;
+};
+
 struct axidma_register_buffer {
     int fd;                         // Anonymous file descritpor for DMA buffer
     size_t size;                    // The size of the external DMA buffer

--- a/include/axidma_ioctl.h
+++ b/include/axidma_ioctl.h
@@ -108,6 +108,11 @@ struct axidma_video_transaction {
     size_t depth;               // The size of each pixel in bytes
 };
 
+struct axidma_residue {
+    int channel_id;             // The id of the DMA channel
+    unsigned int residue;       // The returned residue
+};
+
 /*----------------------------------------------------------------------------
  * IOCTL Interface
  *----------------------------------------------------------------------------*/
@@ -116,7 +121,7 @@ struct axidma_video_transaction {
 #define AXIDMA_IOCTL_MAGIC              'W'
 
 // The number of IOCTL's implemented, used for verification
-#define AXIDMA_NUM_IOCTLS               10
+#define AXIDMA_NUM_IOCTLS               11
 
 /**
  * Returns the number of available DMA channels in the system.
@@ -301,6 +306,16 @@ struct axidma_video_transaction {
  **/
 #define AXIDMA_DMA_VIDEO_WRITE          _IOR(AXIDMA_IOCTL_MAGIC, 7, \
                                              struct axidma_video_transaction)
+
+/**
+ * Get the residue of the last transaction
+ *
+ * Inputs:
+ *  - channel_id - The id for the channel you want to get the residue.
+ *  - residue - The returned residue.
+ **/
+#define AXIDMA_DMA_RESIDUE              _IOR(AXIDMA_IOCTL_MAGIC, 10, \
+                                             struct axidma_residue)
 
 /**
  * Stops all transactions on the given DMA channel.

--- a/include/libaxidma.h
+++ b/include/libaxidma.h
@@ -47,18 +47,33 @@ typedef struct array {
 typedef void (*axidma_cb_t)(int channel_id, void *data);
 
 /**
- * Initializes an AXI DMA device, returning a handle to the device.
+ * Initializes the first AXI DMA device, returning a handle to the device.
  *
- * There is only one AXI DMA device, since it represents all of the available
- * channels. Thus, this function should only be invoked once, unless a call has
- * been made to #axidma_destroy. Otherwise, this function will abort.
+ * There is only one AXI DMA device per DMA, since it represents all of the
+ * available channels. Thus, this function should only be invoked once, unless
+ * a call has been made to #axidma_destroy. Otherwise, this function will abort.
+ *
+ * This function is equivalent with axidma_init_dev(0).
  *
  * @return A handle to the AXI DMA device on success, NULL on failure.
  **/
 struct axidma_dev *axidma_init();
 
 /**
- * Tears down and destroys an AXI DMA device, deallocating its resources.
+ * Initializes a AXI DMA device, returning a handle to the device.
+ *
+ * There is only one AXI DMA device per DMA, since it represents all of the
+ * available channels. Thus, this function should only be invoked once for every
+ * DMA, unless a call has been made to #axidma_destroy. Otherwise, this function
+ * will abort.
+ *
+ * @param[in] index The index of the device, specified in the device tree.
+ * @return A handle to the AXI DMA device on success, NULL on failure.
+ **/
+struct axidma_dev *axidma_init_dev(unsigned int index);
+
+/**
+ * Tears down and destroys one AXI DMA device, deallocating its resources.
  *
  * @param[in] dev An #axidma_dev_t returned by #axidma_init.
  **/

--- a/include/libaxidma.h
+++ b/include/libaxidma.h
@@ -268,6 +268,16 @@ int axidma_video_transfer(axidma_dev_t dev, int display_channel, size_t width,
         size_t height, size_t depth, void **frame_buffers, int num_buffers);
 
 /**
+ * Get the residue of the last transaction
+ *
+ * @param[in] dev An #axidma_dev_t returned by #axidma_init.
+ * @param[in] channel DMA channel.
+ * @param[in] residue A pointer to store the returned residue.
+ * @return 0 upon success, a negative number on failure.
+ **/
+int axidma_get_residue(axidma_dev_t dev, int channel, unsigned int *residue);
+
+/**
  * Stops the DMA transfer on specified DMA channel.
  *
  * This function stops transfers on either DMA or VDMA channels.

--- a/library/libaxidma.c
+++ b/library/libaxidma.c
@@ -529,6 +529,24 @@ int axidma_video_transfer(axidma_dev_t dev, int display_channel, size_t width,
     return rc;
 }
 
+/* This function gets the residue of the last transaction. */
+int axidma_get_residue(axidma_dev_t dev, int channel, unsigned int *residue) {
+    int rc;
+    struct axidma_residue res;
+
+    res.channel_id = channel;
+    rc = ioctl(dev->fd, AXIDMA_DMA_RESIDUE, &res);
+
+    if (rc < 0) {
+        perror("Failed to get the DMA residue");
+    }
+    else {
+        *residue = res.residue;
+    }
+
+    return rc;
+}
+
 /* This function stops all transfers on the given channel with the given
  * direction. This function is required to stop any video transfers, or any
  * non-blocking transfers. */

--- a/library/libaxidma.c
+++ b/library/libaxidma.c
@@ -41,7 +41,6 @@ typedef struct dma_channel {
 
 // The structure that represents the AXI DMA device
 struct axidma_dev {
-    bool initialized;           ///< Indicates initialization for this struct.
     int fd;                     ///< File descriptor for the device
     array_t dma_tx_chans;       ///< Channel id's for the DMA transmit channels
     array_t dma_rx_chans;       ///< Channel id's for the DMA receive channels
@@ -50,9 +49,6 @@ struct axidma_dev {
     int num_channels;           ///< The total number of DMA channels
     dma_channel_t *channels;    ///< All of the VDMA/DMA channels in the system
 };
-
-// The DMA device structure, and a boolean checking if it's already open
-struct axidma_dev axidma_dev = {0};
 
 /*----------------------------------------------------------------------------
  * Private Helper Functions
@@ -187,18 +183,20 @@ static int probe_channels(axidma_dev_t dev)
 
 static void axidma_callback(int signal, siginfo_t *siginfo, void *context)
 {
-    int channel_id;
+    struct axidma_dev *dev = siginfo->si_ptr;
+    int channel_id = siginfo->si_errno;
     dma_channel_t *chan;
 
-    assert(0 <= siginfo->si_int && siginfo->si_int < axidma_dev.num_channels);
+    assert(dev != NULL);
+    assert(channel_id >= 0);
+    assert(channel_id < dev->num_channels);
 
     // Silence the compiler
     (void)signal;
     (void)context;
 
     // If the user defined a callback for a given channel, invoke it
-    channel_id = siginfo->si_int;
-    chan = &axidma_dev.channels[channel_id];
+    chan = &dev->channels[channel_id];
     if (chan->callback != NULL) {
         chan->callback(channel_id, chan->user_data);
     }
@@ -212,6 +210,7 @@ static void axidma_callback(int signal, siginfo_t *siginfo, void *context)
 static int setup_dma_callback(axidma_dev_t dev)
 {
     int rc;
+    struct axidma_signal_info sig_info;
     struct sigaction sigact;
 
     // Register a signal handler for the real-time signal
@@ -224,8 +223,11 @@ static int setup_dma_callback(axidma_dev_t dev)
         return rc;
     }
 
-    // Tell the driver to deliver us SIGRTMIN upon DMA completion
-    rc = ioctl(dev->fd, AXIDMA_SET_DMA_SIGNAL, SIGRTMIN);
+    sig_info.signal = SIGRTMIN;
+    sig_info.user_data = dev;
+
+    // Tell the driver to deliver us SIGRTMIN and dev upon DMA completion
+    rc = ioctl(dev->fd, AXIDMA_SET_DMA_SIGNAL, &sig_info);
     if (rc < 0) {
         perror("Failed to set the DMA callback signal");
         return rc;
@@ -270,38 +272,56 @@ static unsigned long dir_to_ioctl(enum axidma_dir dir)
  * Public Interface
  *----------------------------------------------------------------------------*/
 
-/* Initializes the AXI DMA device, returning a new handle to the
- * axidma_device. */
 struct axidma_dev *axidma_init()
 {
-    assert(!axidma_dev.initialized);
+    return axidma_init_dev(0);
+}
+
+/* Initializes the AXI DMA device, returning a new handle to the
+ * axidma_device. */
+struct axidma_dev *axidma_init_dev(unsigned int index)
+{
+    const unsigned int pathlen = sizeof(AXIDMA_DEV_PATH) + 10;
+    char path[pathlen];
+    struct axidma_dev *dev;
+
+    dev = calloc(1, sizeof(struct axidma_dev));
+    if (dev == NULL) {
+        perror("Can't allocate AXI DMA structure");
+        return NULL;
+    }
 
     // Open the AXI DMA device
-    axidma_dev.fd = open(AXIDMA_DEV_PATH, O_RDWR|O_EXCL);
-    if (axidma_dev.fd < 0) {
+    if (index) {
+        snprintf(path, pathlen, "%s%d", AXIDMA_DEV_PATH, index);
+        dev->fd = open(path, O_RDWR|O_EXCL);
+    }
+    else
+        dev->fd = open(AXIDMA_DEV_PATH, O_RDWR|O_EXCL);
+
+    if (dev->fd < 0) {
         perror("Error opening AXI DMA device");
         fprintf(stderr, "Expected the AXI DMA device at the path `%s`\n",
-                AXIDMA_DEV_PATH);
+                index ? path : AXIDMA_DEV_PATH);
         return NULL;
     }
 
     // Query the AXIDMA device for all of its channels
-    if (probe_channels(&axidma_dev) < 0) {
-        close(axidma_dev.fd);
+    if (probe_channels(dev) < 0) {
+        close(dev->fd);
         return NULL;
     }
 
     // TODO: Should really check that signal is not already taken
     /* Setup a real-time signal to indicate when transactions have completed,
      * and request the driver to send them to us. */
-    if (setup_dma_callback(&axidma_dev) < 0) {
-        close(axidma_dev.fd);
+    if (setup_dma_callback(dev) < 0) {
+        close(dev->fd);
         return NULL;
     }
 
     // Return the AXI DMA device to the user
-    axidma_dev.initialized = true;
-    return &axidma_dev;
+    return dev;
 }
 
 // Tears down the given AXI DMA device structure
@@ -320,8 +340,6 @@ void axidma_destroy(axidma_dev_t dev)
         assert(false);
     }
 
-    // Free the device structure
-    axidma_dev.initialized = false;
     return;
 }
 


### PR DESCRIPTION
* Add axidma_get_residue() 

This commit adds a new IOCTL which can be used to retrieve the residue (= how many bytes weren't transmitted/received), which can be used to calculate how many bytes were really received.
Unfortunately the Xilinx kernel is bugged at the moment and always returns 0, no matter how many bytes have been actually transmitted. As soon as I understand which is the procedure to propose kernel patches to Xilinx I'll try to get my patch merged.

* Add MODULE_DEVICE_TABLE to automatically load the module when needed 

If this module is built in-tree (Linux doesn't automatically load out-of-tree modules), a matching entry in the DT is enough to automatically load this module.

* Add support for multiple AXI DMA devices 

To accomplish this a couple of backward-incompatible changes were needed. The library interface is the same, but the IOCTLs have changed a little.

The channel_id value in the callback is now passed in the sig_info.si_errno field: this is not very clean, but it is easy to be implemented (and the si_errno field wasn't used anyways). Feel free to criticize this solution.


Tell me if you're interested in some (or all) of these commits.