### PR TITLE
Older linux support and DMA buffer offset

### DIFF
--- a/driver/axidma_chrdev.c
+++ b/driver/axidma_chrdev.c
@@ -88,7 +88,7 @@ dma_addr_t axidma_uservirt_to_dma(struct axidma_device *dev, void *user_addr,
                                   user_addr, size);
         if (valid) {
             offset = (dma_addr_t)(user_addr - dma_alloc->user_addr);
-            return dma_alloc->dma_addr;
+            return dma_alloc->dma_addr + offset;
         }
     }
 

--- a/driver/axidma_dma.c
+++ b/driver/axidma_dma.c
@@ -12,7 +12,15 @@
 // Kernel dependencies
 #include <linux/delay.h>            // Milliseconds to jiffies converstion
 #include <linux/wait.h>             // Completion related functions
+
+/* <linux/signal.h> was moved to <linux/sched/signal.h> in the 4.11 kernel */
+#include <linux/version.h>
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,11,0)
+#include <linux/sched.h>            // Send signal to process function
+#else
 #include <linux/sched/signal.h>     // send_sig_info function
+#endif
+
 #include <linux/dmaengine.h>        // DMA types and functions
 #include <linux/slab.h>             // Allocation functions
 #include <linux/errno.h>            // Linux error codes


### PR DESCRIPTION
The driver supports older linux kernel versions than 4.11 and can read data with an offset to the DMA buffer.