### PR TITLE
Added vdma oneway transfer to library, fixed passing of frame info

### DIFF
--- a/driver/axidma_dma.c
+++ b/driver/axidma_dma.c
@@ -387,6 +387,11 @@ int axidma_read_transfer(struct axidma_device *dev,
     rx_tfr.process = get_current();
     rx_tfr.cb_data = &dev->cb_data[trans->channel_id];
 
+    // Add in the frame information for VDMA transfers
+    if (rx_chan->type == AXIDMA_VDMA) {
+        memcpy(&rx_tfr.frame, &trans->frame, sizeof(rx_tfr.frame));
+    }
+
     // Prepare the receive transfer
     rc = axidma_prep_transfer(rx_chan, &rx_tfr);
     if (rc < 0) {
@@ -436,6 +441,11 @@ int axidma_write_transfer(struct axidma_device *dev,
     tx_tfr.notify_signal = dev->notify_signal;
     tx_tfr.process = get_current();
     tx_tfr.cb_data = &dev->cb_data[trans->channel_id];
+    
+    // Add in the frame information for VDMA transfers
+    if (tx_chan->type == AXIDMA_VDMA) {
+        memcpy(&tx_tfr.frame, &trans->frame, sizeof(tx_tfr.frame));
+    }
 
     // Prepare the transmit transfer
     rc = axidma_prep_transfer(tx_chan, &tx_tfr);

--- a/include/libaxidma.h
+++ b/include/libaxidma.h
@@ -214,6 +214,32 @@ int axidma_oneway_transfer(axidma_dev_t dev, int channel, void *buf, size_t len,
         bool wait);
 
 /**
+ * Performs a single DMA transfer in the specified direction on the DMA channel.
+ *
+ * This function will perform a single DMA transfer using the specified buffer.
+ * If wait is false, then this function will be non-blocking, and if the user
+ * registered a callback function, it will be invoked upon completion of the
+ * transfer.
+ *
+ * The addresses \p buf and \p buf+\p len must be within a buffer that was
+ * previously allocated by #axidma_malloc or registered with
+ * #axidma_register_buffer. This function will abort if the channel is invalid.
+ *
+ * @param[in] dev An #axidma_dev_t returned by #axidma_init.
+ * @param[in] channel VDMA channel the transfer is performed on.
+ * @param[in] buf Address of the DMA buffer to transfer, previously allocated by
+ *                #axidma_malloc or registered with #axidma_register_buffer.
+ * param[in] rx_frame Information about the video frame for the receive
+ *                     channel.
+ * @param[in] len Number of bytes that will be transfered.
+ * @param[in] wait Indicates if the transfer should be synchronous or
+ *                 asynchronous. If true, this function will block.
+ * @return 0 upon success, a negative number on failure.
+ **/
+int axivdma_oneway_transfer(axidma_dev_t dev, int channel,  void *buf, 
+        struct axidma_video_frame *frame, size_t len, bool wait);
+
+/**
  * Performs a two coupled DMA transfers, one in the receive direction, the other
  * in the transmit direction.
  *


### PR DESCRIPTION
For applications where single frames need to be pulled in with VDMA, it may be required to have a single transfer function besides the continuously running video transfer.
I added a new function to the library rather than change the signature of the existing axidma_oneway_transfer function in order to preserve backwards compatibility. In this work i also discovered a small bug in the dma layer where frame size information was not passed through for single transactions.